### PR TITLE
Create dict of domain as key and org as value

### DIFF
--- a/trackingprotection_tools/DisconnectParser.py
+++ b/trackingprotection_tools/DisconnectParser.py
@@ -72,7 +72,9 @@ class DisconnectParser(object):
                 "location in `blocklist` or `blocklist_url`?"
             )
         rv = self._parse_blocklist(self._raw_blocklist)
-        self._categorized_blocklist, self._tagged_domains = rv
+        (self._categorized_blocklist,
+         self._tagged_domains,
+         self._company_classifier) = rv
         self._blocklist = self._flatten_blocklist(self._categorized_blocklist)
 
         # Entitylist
@@ -159,6 +161,7 @@ class DisconnectParser(object):
             print("Parsing raw list into categorized list...")
 
         collapsed = dict()
+        company_classifier = dict()
         self._all_list_categories = set(blocklist['categories'].keys())
         for category in self._all_list_categories:
             collapsed[category] = set()
@@ -208,12 +211,12 @@ class DisconnectParser(object):
                                 collapsed[new_cat].add(domain)
                                 remapping_count[new_cat] += 1
                             collapsed[cat].add(domain)
+                            company_classifier[domain] = org
         if self.verbose:
             for category, count in remapping_count.items():
                 print("Remapped %d domains from Disconnect to %s" % (
                     count, category))
-
-        return collapsed, tagged_domains
+        return collapsed, tagged_domains, company_classifier
 
     def _flatten_blocklist(self, blocklist):
         """Generate a flattened version of the blocklist category map"""

--- a/trackingprotection_tools/test/test_disconnect_parser.py
+++ b/trackingprotection_tools/test/test_disconnect_parser.py
@@ -308,3 +308,27 @@ class TestDisconnectParser(BaseTest):
                 blocklist=self.short_blocklist_file,
                 disconnect_mapping=self.bad_mapping_file
             )
+
+    def test_parse_blocklist_creates_domain_to_company_mapping(self):
+        parser = DisconnectParser(
+            self.short_blocklist_file,
+            self.entitylist_file,
+            disconnect_mapping=self.mapping_file
+        )
+
+        assert(
+            parser._all_list_categories == set(
+                ["Analytics", "Disconnect", "Advertising", "Social"]
+            )
+        )
+        assert(len(parser._blocklist + 1) == len(parser._company_classifier))
+        assert(
+            parser._company_classifier == {
+                "a.should-be-ad-tracker.example": "Varied Tracker",
+                "analytics-trackerA-1.example": "Analytics Tracker A",
+                "social-trackerA.example": "Social Tracker A",
+                "ad-trackerA-1.example": "Advertising Tracker A",
+                "b.should-be-ad-tracker.example": "Varied Tracker",
+                "should-be-analytics-tracker.example": "Varied Tracker"
+            }
+        )

--- a/trackingprotection_tools/test/test_disconnect_parser.py
+++ b/trackingprotection_tools/test/test_disconnect_parser.py
@@ -321,7 +321,7 @@ class TestDisconnectParser(BaseTest):
                 ["Analytics", "Disconnect", "Advertising", "Social"]
             )
         )
-        assert(len(parser._blocklist + 1) == len(parser._company_classifier))
+        assert(len(parser._blocklist) == len(parser._company_classifier))
         assert(
             parser._company_classifier == {
                 "a.should-be-ad-tracker.example": "Varied Tracker",


### PR DESCRIPTION
# About this PR
There are repeated requests about information on domains and their respective organizations blocked on specific list(s). This PR creates a function that provides the information in the console log and in a file output

# Acceptance Criteria
- [ ] Existing functionality works as is
- [ ] When a specific list name (*digest256) is specified in [here](https://github.com/mozilla-services/shavar-list-creation/pull/100/files#diff-8c5c15d9cbbefc2ec320aa3f2a253290R479) it outputs a log message like:
```
/// DOMAINS BLOCKED IN base-track-digest256: 2015
/// COMPANIES BLOCKED IN base-track-digest256: 1128
```
- [ ] When a specific list name is  specified in [here](https://github.com/mozilla-services/shavar-list-creation/pull/100/files#diff-8c5c15d9cbbefc2ec320aa3f2a253290R479) it creates two comma separated value files named `companies-blocked` and `domains-blocked`